### PR TITLE
Increase audio element width to improve accessibility

### DIFF
--- a/content/stylesheets/layout.css
+++ b/content/stylesheets/layout.css
@@ -140,7 +140,7 @@ aside                                           { background: #EEE; margin-botto
 .small.intro                                    { height: 152px; }
 .intro ul                                       { margin-top: 2em; }
 
-audio                                           { padding: 0.5em 0em 0em 10px; width: 226px; }
+audio                                           { padding: 0.5em 0em 0em 10px; width: 100%; }
 aside.danne                                     { margin: 10px 10px 0px 20px; padding: 10px 15px !important; border: 15px solid #EEE; background-color: #FFF; text-align: left !important; }
 header.span                                     { margin: 10px 25px 0px 35px; padding: 0px 15px 5px 15px !important; text-align: center !important; font-size: 19pt; }
 


### PR DESCRIPTION
Hello! 

I was browsing http://linenoise.io/sets/the_meadow/index.html today to listen to the tracklist. 

I noticed that the time slider of the <audio> element control panel is little small, thus making it hard to skip to any specific timestamp. 

Haven't worked much with CSS but searching around on StackOverflow, I found the proposal to set the width to 100%. I made the change and tried it out on mobile, tab and mac and it seem to work as expected.

Original
![image](https://user-images.githubusercontent.com/6646375/88263292-a8e8dc00-cc7e-11ea-97d7-80c847e2d8e8.png)


After width:100%

Laptop
![image](https://user-images.githubusercontent.com/6646375/88263243-8ce53a80-cc7e-11ea-9281-d7502a357d71.png)

Tablet
![image](https://user-images.githubusercontent.com/6646375/88263347-c027c980-cc7e-11ea-9bab-c1efa39e64fc.png)


Mobile
![image](https://user-images.githubusercontent.com/6646375/88263448-e77e9680-cc7e-11ea-9774-2b49127f33f7.png)

